### PR TITLE
Changed the way how `check_verified_emails` method works.

### DIFF
--- a/jazzband/models.py
+++ b/jazzband/models.py
@@ -113,8 +113,11 @@ class User(db.Model, Helpers, Syncable, UserMixin):
         return not self.is_banned
 
     def check_verified_emails(self):
+        # User can have multiple emails, 
+        # we just want to ensure he has at least one:
+        # see https://github.com/jazzband/website/issues/8 for more.
         return (self.email_addresses.filter_by(verified=True)
-                                    .one_or_none() is not None)
+                                    .first() is not None)
 
 
 class EmailAddress(db.Model, Helpers, Syncable):


### PR DESCRIPTION
The problem was with multiple emails, `.one_or_none()` raise an exception on that.
So it was immpossible to join the `jazzband`.
Now it is fixed by changing the query method to: `.first()`

References: https://github.com/jazzband/website/issues/8