### PR TITLE
Fix z-index for .join menu

### DIFF
--- a/jazzband/static/scss/_base.scss
+++ b/jazzband/static/scss/_base.scss
@@ -193,6 +193,7 @@ a {
 .join {
     text-align: left;
     max-width: 300px;
+    z-index: 2;
 }
 @media all and (max-width: 1023px) {
     body.about > .wrapper {


### PR DESCRIPTION
Something is interfering with the `.join` menu on this page: https://jazzband.co/about/conduct. My cursor doesn't change to a click cursor when hovering over the menu items. This z-index change fixes the problem.