### PR TITLE
refactor: enhance ux by using a sticky table head

### DIFF
--- a/jazzband/static/css/_base.scss
+++ b/jazzband/static/css/_base.scss
@@ -389,6 +389,10 @@ th {
     font-weight: $semi-bold;
 }
 table.projects-index {
+    thead {
+        position: sticky;
+        top: 0;
+    }
     td,
     th {
         &:first-child {


### PR DESCRIPTION
As the title describes, this little change enhances ux when viewing the projects list by using a sticky table head. 

Reason: If you scroll down the large list of projects you don't know what the numbers in the list mean. This way a user is a bit lost and would need to scroll completly to the top again which is a bad user experience